### PR TITLE
Expand Gmail Actions to include Inbox Highlights & Configuration

### DIFF
--- a/code/Block/Gmailactions.php
+++ b/code/Block/Gmailactions.php
@@ -1,33 +1,152 @@
 <?php
 
-class Meanbee_Gmailactions_Block_Gmailactions extends Mage_Core_Block_Template {
+class Meanbee_Gmailactions_Block_Gmailactions extends Mage_Core_Block_Template
+{
 
-    public function getViewOrderUrl($order) {
+    public function getViewOrderUrl($order)
+    {
         return Mage::getUrl(
             "sales/order/view",
             array(
                 'order_id' => $order->getId(),
-                '_secure' => Mage::getStoreConfig('web/secure/use_in_frontend')
+                '_secure'  => Mage::getStoreConfig('web/secure/use_in_frontend')
             )
         );
     }
 
-    public function getViewShipmentUrl($order) {
+    /**
+     * @param Mage_Sales_Model_Order $order
+     *
+     * @return string
+     */
+    public function getOrderStatus($order)
+    {
+        $state = $order->getState();
+        $map   = array(
+            'new'             => 'Processing',
+            'pending_payment' => 'ProblemWithOrder',
+            'processing'      => 'Processing',
+            'complete'        => 'Delivered',
+            'closed'          => 'Cancelled',
+            'cancelled'       => 'Cancelled',
+            'holded'          => 'ProblemWithOrder',
+        );
+
+        return 'http://schema.org/OrderStatus/' . $map[$state];
+    }
+
+    public function getViewShipmentUrl($order)
+    {
         return Mage::getUrl(
             "sales/order/shipment",
             array(
                 'order_id' => $order->getId(),
-                '_secure' => Mage::getStoreConfig('web/secure/use_in_frontend')
+                '_secure'  => Mage::getStoreConfig('web/secure/use_in_frontend')
             )
         );
     }
 
-    public function getViewCreditmemoUrl($order) {
+    public function getViewCreditmemoUrl($order)
+    {
         return Mage::getUrl(
             "sales/order/creditmemo",
             array(
                 'order_id' => $order->getId(),
-                '_secure' => Mage::getStoreConfig('web/secure/use_in_frontend')
+                '_secure'  => Mage::getStoreConfig('web/secure/use_in_frontend')
+            )
+        );
+    }
+
+    public function generateOrderArray(Mage_Sales_Model_Order $order)
+    {
+        $array = array(
+            '@context'      => 'http://schema.org',
+            '@type'         => 'Order',
+            'merchant'      => array(
+                '@type' => 'Organization',
+                'name'  => $order->getStore()->getFrontendName(),
+            ),
+            'orderNumber'   => $order->getIncrementId(),
+            'priceCurrency' => $order->getOrderCurrency()->toString(),
+            'price'         => (string) number_format($order->getBaseTotalDue(), 2),
+            'acceptedOffer' => $this->generateAcceptedOfferArray($order),
+        );
+
+        if (!$order->getCustomerIsGuest()) {
+            $array['url'] = $this->getViewOrderUrl($order);
+        }
+
+        return $array;
+    }
+
+    public function generateAcceptedOfferArray(Mage_Sales_Model_Order $order)
+    {
+        $array = array();
+        foreach ($order->getAllItems() as $item) {
+            $_offer = array(
+                '@type'            => 'Offer',
+                'itemOffered'      => array(
+                    '@type' => 'Product',
+                    'name'  => $item->getName(),
+                    'sku'   => $item->getSku(),
+                    'image' => $item->getImageUrl(),
+                ),
+                'price'            => (string) number_format($item->getPrice(), 2),
+                'priceCurrency'    => $order->getBaseCurrency()->getCurrencyCode(),
+                'eligibleQuantity' => array(
+                    '@type' => 'QuantitativeValue',
+                    'value' => $item->getQtyOrdered(),
+                ),
+            );
+
+            $array[] = $_offer;
+        }
+
+        return $array;
+    }
+
+    public function generateShipmentArray(Mage_Sales_Model_Order_Shipment $shipment)
+    {
+        $address         = $shipment->getShippingAddress();
+        $trackingMethods = $shipment->getAllTracks();
+        $primaryTrack    = count($trackingMethods) ? $trackingMethods[0] : false;
+
+        $array = array(
+            '@context'             => 'http://schema.org',
+            '@type'                => 'ParcelDelivery',
+            'deliveryAddress'      => array(
+                '@type'           => 'PostalAddress',
+                'streetAddress'   => $address->getStreetFull(),
+                'addressLocality' => $address->getCity(),
+                'addressRegion'   => $address->getRegionCode(),
+                'addressCountry'  => $address->getCountry(),
+                'postalCode'      => $address->getPostcode(),
+            ),
+            'partOfOrder'          => $this->generateOrderArray($shipment->getOrder()),
+            "expectedArrivalUntil" => date("c", time() + 60 * 60 * 24 * 365.25),
+        );
+
+        if (count($trackingMethods)) {
+            $array['carrier']        = $primaryTrack->getTitle();
+            $array['trackingNumber'] = $primaryTrack->getNumber();
+            $array['trackingUrl']    = $this->helper('shipping')->getTrackingPopUpUrlByTrackId($primaryTrack->getId());
+        }
+
+        return $array;
+    }
+
+    public function generateCreditMemoArray(Mage_Sales_Model_Order $order)
+    {
+        $store = $order->getStore();
+
+        return array(
+            '@context'    => 'http://schema.org',
+            '@type'       => 'EmailMessage',
+            'description' => Mage::getStoreConfig("meanbee_gmailactions_options/creditmemo_email/description", $store),
+            'action'      => array(
+                '@type' => 'ViewAction',
+                'url'   => $this->getViewCreditmemoUrl($order),
+                'name'  => Mage::getStoreConfig('meanbee_gmailactions_options/creditmemo_email/action_name', $store)
             )
         );
     }

--- a/code/etc/config.xml
+++ b/code/etc/config.xml
@@ -49,15 +49,14 @@
     </adminhtml>
     <default>
         <meanbee_gmailactions_options>
-            <shipment_email>
-                <action_name>View Shipment</action_name>
-                <description>Open shipment in browser</description>
-            </shipment_email>
             <order_email>
-                <action_name>View Order</action_name>
-                <description>Open order in browser</description>
+                <enabled>1</enabled>
             </order_email>
+            <shipment_email>
+                <enabled>1</enabled>
+            </shipment_email>
             <creditmemo_email>
+                <enabled>1</enabled>
                 <action_name>View Credit Memo</action_name>
                 <description>Open credit memo in browser</description>
             </creditmemo_email>

--- a/code/etc/system.xml
+++ b/code/etc/system.xml
@@ -17,69 +17,64 @@
             <show_in_store>1</show_in_store>
             <groups>
                 <order_email>
-                    <label>Order Email Options</label>
+                    <label>Order Email Rich Snippet</label>
                     <frontend_type>text</frontend_type>
                     <sort_order>0</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
                     <show_in_store>1</show_in_store>
                     <fields>
-                        <description>
-                            <label>Description</label>
-                            <frontend_type>text</frontend_type>
+                        <enabled>
+                            <label>Enabled</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
                             <sort_order>1</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
-                        </description>
-                        <action_name>
-                            <label>Action Name</label>
-                            <frontend_type>text</frontend_type>
-                            <sort_order>1</sort_order>
-                            <show_in_default>1</show_in_default>
-                            <show_in_website>1</show_in_website>
-                            <show_in_store>1</show_in_store>
-                        </action_name>
+                        </enabled>
                     </fields>
                 </order_email>
                 <shipment_email>
-                    <label>Shipment Email Options</label>
+                    <label>Shipment Email Rich Snippet</label>
                     <frontend_type>text</frontend_type>
                     <sort_order>1</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
                     <show_in_store>1</show_in_store>
                     <fields>
-                        <description>
-                            <label>Description</label>
-                            <frontend_type>text</frontend_type>
+                        <enabled>
+                            <label>Enabled</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
                             <sort_order>1</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
-                        </description>
-                        <action_name>
-                            <label>Action Name</label>
-                            <frontend_type>text</frontend_type>
-                            <sort_order>1</sort_order>
-                            <show_in_default>1</show_in_default>
-                            <show_in_website>1</show_in_website>
-                            <show_in_store>1</show_in_store>
-                        </action_name>
+                        </enabled>
                     </fields>
                 </shipment_email>
                 <creditmemo_email>
-                    <label>Credit Memo Options</label>
+                    <label>Credit Memo Action Button</label>
                     <frontend_type>text</frontend_type>
                     <sort_order>2</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
                     <show_in_store>1</show_in_store>
                     <fields>
+                        <enabled>
+                            <label>Enabled</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>10</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </enabled>
                         <description>
                             <label>Description</label>
                             <frontend_type>text</frontend_type>
-                            <sort_order>1</sort_order>
+                            <sort_order>30</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
@@ -87,7 +82,7 @@
                         <action_name>
                             <label>Action Name</label>
                             <frontend_type>text</frontend_type>
-                            <sort_order>1</sort_order>
+                            <sort_order>20</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>

--- a/design/frontend/template/meanbee/gmailactions/creditmemo.phtml
+++ b/design/frontend/template/meanbee/gmailactions/creditmemo.phtml
@@ -1,16 +1,10 @@
-<?php $_creditmemo = $this->getCreditmemo(); ?>
-<?php $_order = $this->getOrder(); ?>
-<?php if (!$_order->getCustomerIsGuest()): ?>
-<script type="application/ld+json">
-{
-  "@context": "http://schema.org",
-  "@type": "EmailMessage",
-  "description": "<?php echo Mage::getStoreConfig("meanbee_gmailactions_options/creditmemo_email/description"); ?>",
-  "action": {
-    "@type": "ViewAction",
-    "url": "<?php echo $this->getViewCreditmemoUrl($_order); ?>",
-    "name": "<?php echo Mage::getStoreConfig("meanbee_gmailactions_options/creditmemo_email/action_name"); ?>"
-  }
+<?php
+/** @var Mage_Core_Model_Sales_Order $_order */
+$_order = $this->getOrder();
+if (!Mage::getStoreConfigFlag('meanbee_gmailactions_options/creditmemo_email/enabled', $_order->getStore())) {
+    return;
 }
+?>
+<script type="application/ld+json">
+    <?php echo json_encode($this->generateCreditMemoArray($_order)); ?>
 </script>
-<?php endif; ?>

--- a/design/frontend/template/meanbee/gmailactions/order.phtml
+++ b/design/frontend/template/meanbee/gmailactions/order.phtml
@@ -1,15 +1,10 @@
-<?php $_order = $this->getOrder(); ?>
-<?php if(!$_order->getCustomerIsGuest()): ?>
-<script type="application/ld+json">
-{
-  "@context": "http://schema.org",
-  "@type": "EmailMessage",
-  "description": "<?php echo Mage::getStoreConfig("meanbee_gmailactions_options/order_email/description"); ?>",
-  "action": {
-    "@type": "ViewAction",
-    "url": "<?php echo $this->getViewOrderUrl($_order); ?>",
-    "name": "<?php echo Mage::getStoreConfig("meanbee_gmailactions_options/order_email/action_name"); ?>"
-  }
+<?php
+/** @var Mage_Core_Model_Sales_Order $_order */
+$_order = $this->getOrder();
+if (!Mage::getStoreConfigFlag('meanbee_gmailactions_options/order_email/enabled', $_order->getStore())) {
+    return;
 }
+?>
+<script type="application/ld+json">
+    <?php echo json_encode($this->generateOrderArray($_order)); ?>
 </script>
-<?php endif; ?>

--- a/design/frontend/template/meanbee/gmailactions/shipment.phtml
+++ b/design/frontend/template/meanbee/gmailactions/shipment.phtml
@@ -1,16 +1,10 @@
-<?php $_shipment = $this->getShipment(); ?>
-<?php $_order = $this->getOrder(); ?>
-<?php if (!$_order->getCustomerIsGuest()): ?>
-<script type="application/ld+json">
-{
-  "@context": "http://schema.org",
-  "@type": "EmailMessage",
-  "description": "<?php echo Mage::getStoreConfig("meanbee_gmailactions_options/shipment_email/description"); ?>",
-  "action": {
-    "@type": "ViewAction",
-    "url": "<?php echo $this->getViewShipmentUrl($_order); ?>",
-    "name": "<?php echo Mage::getStoreConfig("meanbee_gmailactions_options/shipment_email/action_name"); ?>"
-  }
+<?php
+/** @var Mage_Core_Model_Sales_Order_Shipment $_shipment */
+$_shipment = $this->getShipment();
+if (!Mage::getStoreConfigFlag('meanbee_gmailactions_options/shipment_email/enabled', $_shipment->getStore())) {
+    return;
 }
+?>
+<script type="application/ld+json">
+    <?php echo json_encode($this->generateShipmentArray($_shipment)); ?>
 </script>
-<?php endif; ?>


### PR DESCRIPTION
- Expands Order Email to include information about the products ordered and their prices
- Expands Shipment Email to include information about the products shipped and tracking information
- Creates configuration options for disabling each type of Rich Snippet or Action Button
- Refactors Code to move generation of Schema.org objects to the Gmailactions block
- Refactors Code to PSR Standards as a side-effect of the IDE

Potential for Improvement:
- There are a lot more attributes that are not specified in this code such as Order Status & more (that I had trouble running through Google's validator or otherwise)
- Creating a Shipment should be modified to have a date that the item is expected to arrive by, as this code is using "a year from shipment."  Which doesn't look good if you don't attach a tracking number.

More information about this feature: https://developers.google.com/gmail/markup/highlights#order

In addition to Inbox by Gmail, these display order information in Google Now.

In Gmail these fall back to the buttons (though the text is no longer customizable)
